### PR TITLE
Fix failing tests and harden PWA utilities

### DIFF
--- a/jarvis-chat/src/components/pwa/PWAStatus.tsx
+++ b/jarvis-chat/src/components/pwa/PWAStatus.tsx
@@ -16,7 +16,11 @@ export const PWAStatus: React.FC<PWAStatusProps> = ({
     usePWAInstall();
 
   // Detect display mode
-  const isStandalone = window.matchMedia('(display-mode: standalone)').matches;
+  const standaloneQuery =
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia('(display-mode: standalone)')
+      : null;
+  const isStandalone = standaloneQuery ? standaloneQuery.matches : false;
   const isMobile =
     /Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
       navigator.userAgent

--- a/jarvis-chat/src/components/pwa/__tests__/InstallPrompt.test.tsx
+++ b/jarvis-chat/src/components/pwa/__tests__/InstallPrompt.test.tsx
@@ -49,7 +49,7 @@ describe('InstallPrompt', () => {
     render(<InstallPrompt showDelay={0} />);
 
     await waitFor(() => {
-      expect(screen.getByText('Install JARVIS Chat')).toBeInTheDocument();
+      expect(screen.getAllByText('Install JARVIS Chat')[0]).toBeInTheDocument();
     });
 
     expect(
@@ -118,7 +118,7 @@ describe('InstallPrompt', () => {
     render(<InstallPrompt showDelay={0} />);
 
     await waitFor(() => {
-      expect(screen.getByText('Install JARVIS Chat')).toBeInTheDocument();
+      expect(screen.getAllByText('Install JARVIS Chat')[0]).toBeInTheDocument();
     });
 
     const dismissButton = screen.getByRole('button', { name: '' }); // X button has no text

--- a/jarvis-chat/src/hooks/__tests__/useChat.test.ts
+++ b/jarvis-chat/src/hooks/__tests__/useChat.test.ts
@@ -125,7 +125,9 @@ describe('useChat', () => {
 
     expect(mockChatService.processChatMessage).toHaveBeenCalledWith(
       'Hello',
-      mockUser.id
+      mockUser.id,
+      undefined,
+      undefined
     );
     expect(result.current.messages).toHaveLength(2);
     expect(result.current.messages[0].content).toBe('Hello');
@@ -150,7 +152,9 @@ describe('useChat', () => {
     expect(result.current.isLoading).toBe(false);
 
     // Should have temp user message with error status and error AI message
-    expect(result.current.messages).toHaveLength(2);
+    await waitFor(() => {
+      expect(result.current.messages).toHaveLength(2);
+    });
     expect(result.current.messages[0].status).toBe('error');
     expect(result.current.messages[1].role).toBe('assistant');
     expect(result.current.messages[1].status).toBe('error');

--- a/jarvis-chat/src/hooks/useChat.ts
+++ b/jarvis-chat/src/hooks/useChat.ts
@@ -109,14 +109,7 @@ export const useChat = () => {
       } catch (err) {
         console.error('Failed to send message:', err);
 
-        // Update temporary message to show error
-        setMessages(prev =>
-          prev.map(m =>
-            m.id === tempUserMessage.id ? { ...m, status: 'error' as const } : m
-          )
-        );
-
-        // Add error message from AI
+        // Add error message from AI and mark user message as error
         const errorMessage: Message = {
           id: `error-${Date.now()}`,
           content:
@@ -126,7 +119,11 @@ export const useChat = () => {
           status: 'error',
         };
 
-        setMessages(prev => [...prev, errorMessage]);
+        setMessages(prev => [
+          ...prev.filter(m => m.id !== tempUserMessage.id),
+          { ...tempUserMessage, status: 'error' as const },
+          errorMessage,
+        ]);
         setError(err instanceof Error ? err.message : 'Failed to send message');
       } finally {
         setIsLoading(false);

--- a/jarvis-chat/src/lib/__tests__/assignmentSystem.test.ts
+++ b/jarvis-chat/src/lib/__tests__/assignmentSystem.test.ts
@@ -83,10 +83,15 @@ describe('BugAssignmentSystem', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset internal state between tests
+    (bugAssignmentSystem as any).assignmentHistory.clear();
+    (bugAssignmentSystem as any).initializeTeamMembers();
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    (bugAssignmentSystem as any).assignmentHistory.clear();
+    (bugAssignmentSystem as any).initializeTeamMembers();
   });
 
   describe('Manual Assignment', () => {

--- a/jarvis-chat/src/lib/__tests__/bugReporting.test.ts
+++ b/jarvis-chat/src/lib/__tests__/bugReporting.test.ts
@@ -57,7 +57,8 @@ vi.mock('../performanceMetrics', () => ({
         authErrors: 0,
         totalErrors: 3
       }
-    }))
+    })),
+    getActiveAlerts: vi.fn(() => [])
   }
 }));
 
@@ -225,7 +226,7 @@ describe('BugReportingService', () => {
       'system',
       'Failed to create bug report',
       expect.objectContaining({
-        error: 'Network error'
+        error: expect.stringContaining('Network error')
       })
     );
   });

--- a/jarvis-chat/src/lib/assignmentSystem.ts
+++ b/jarvis-chat/src/lib/assignmentSystem.ts
@@ -240,9 +240,23 @@ class BugAssignmentSystem {
       // Setup escalation monitoring
       this.setupEscalationMonitoring(bugId, assigneeId);
 
-      // Send notification
+      // Send notification (non-blocking)
       if (notify) {
-        await sendAssignmentNotification(bugId, assigneeId, assignerId, reason);
+        try {
+          await sendAssignmentNotification(bugId, assigneeId, assignerId, reason);
+        } catch (notifyError) {
+          centralizedLogging.warn(
+            'assignment-system',
+            'system',
+            'Failed to send assignment notification',
+            {
+              correlationId,
+              bugId,
+              assigneeId,
+              error: notifyError instanceof Error ? notifyError.message : notifyError,
+            }
+          );
+        }
       }
 
       // Track assignment event


### PR DESCRIPTION
## Summary
- Prevent `PWAStatus` from crashing when `matchMedia` is unavailable
- Ensure chat errors preserve the user's message and update tests
- Reset assignment system state between tests and ignore notification failures
- Expand bug reporting test mocks for monitoring data
- Adjust PWA install prompt tests for multiple elements

## Testing
- `npm test src/hooks/__tests__/useChat.test.ts`
- `npm test src/lib/__tests__/bugReporting.test.ts`
- `npm test src/components/pwa/__tests__/PWAStatus.test.tsx`
- `npm test src/components/pwa/__tests__/InstallPrompt.test.tsx`
- `npm test src/lib/__tests__/assignmentSystem.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689ab00ed8348333949f44fb7d6f049b